### PR TITLE
Updated java-cloudant dependency version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# Unreleased
+[IMPROVED] - Updated java-cloudant dependency to version 2.4.3
+
 # 0.1.1 (2016-03-11)
 - Updated to a semver compliant three digit version number.
 

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ subprojects {
 
     dependencies {
         // Cloudant client (java-cloudant) version
-        def javaCloudantVersion = '2.4.1'
+        def javaCloudantVersion = '2.4.3'
         // Dependency on java-cloudant
         compile group: 'com.cloudant', name: 'cloudant-client', version: javaCloudantVersion
         // Dependencies for inheriting javadoc and creating doc links


### PR DESCRIPTION
_What_
Updated the version of the java-cloudant dependency to version 2.4.3.

_Testing_
No new tests, CI testing passes
